### PR TITLE
[DEGA-1468] match_not_all_of_int and match__all_of_int optimization.

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -18,6 +18,8 @@
 #include "value.h"
 #include "var.h"
 
+#define DEGA_1294
+
 struct ast_node* ast_node_create()
 {
     struct ast_node* node = bcalloc(sizeof(*node));
@@ -606,6 +608,17 @@ static bool match_not_all_of_int(struct value variable, struct ast_list_expr lis
         xs = list_expr.value.integer_list_value->integers;
         x_count = list_expr.value.integer_list_value->count;
     }
+#ifdef DEGA_1294
+    if (x_count == 1) {
+        return (d64binary_search(ys, y_count, xs[0]) == true);
+    }
+    if (x_count == 2) {
+        return (d64binary_search(ys, y_count, xs[0]) == true || d64binary_search(ys, y_count, xs[1]) == true);
+    }
+    if (x_count == 3) {
+        return (d64binary_search(ys, y_count, xs[0]) == true || d64binary_search(ys, y_count, xs[1]) == true || d64binary_search(ys, y_count, xs[2]) == true);
+    }
+#endif
     size_t i = 0, j = 0;
     while(i < x_count && j < y_count) {
         int64_t x = xs[i];
@@ -665,6 +678,17 @@ static bool match_all_of_int(struct value variable, struct ast_list_expr list_ex
     int64_t* ys = variable.integer_list_value->integers;
     size_t y_count = variable.integer_list_value->count;
     if(x_count <= y_count) {
+#ifdef DEGA_1294
+        if (x_count == 1) {
+            return (d64binary_search(ys, y_count, xs[0]) == true);
+        }
+        if (x_count == 2) {
+            return (d64binary_search(ys, y_count, xs[0]) == true && d64binary_search(ys, y_count, xs[1]) == true);
+        }
+        if (x_count == 3) {
+            return (d64binary_search(ys, y_count, xs[0]) == true && d64binary_search(ys, y_count, xs[1]) == true && d64binary_search(ys, y_count, xs[2]) == true);
+        }
+#endif
         size_t i = 0, j = 0;
         while(i < y_count && j < x_count) {
             int64_t x = xs[j];

--- a/src/ast.c
+++ b/src/ast.c
@@ -18,9 +18,6 @@
 #include "value.h"
 #include "var.h"
 
-// #define DEGA_1294
-#define DEGA_1468
-
 struct ast_node* ast_node_create()
 {
     struct ast_node* node = bcalloc(sizeof(*node));
@@ -591,8 +588,6 @@ static bool match_special_expr(
     }
 }
 
-#ifdef DEGA_1468
-
 size_t next_low(const int64_t arr[], size_t low, size_t count, int64_t x)
 {
 //    assert(low <= high);
@@ -645,57 +640,6 @@ static bool match_not_all_of_int(struct value variable, struct ast_list_expr lis
     return false;
 }
 
-#else
-
-static bool match_not_all_of_int(struct value variable, struct ast_list_expr list_expr)
-{
-    int64_t* xs;
-    size_t x_count;
-    int64_t* ys;
-    size_t y_count;
-    if(variable.integer_list_value->count < list_expr.value.integer_list_value->count) {
-        xs = variable.integer_list_value->integers;
-        x_count = variable.integer_list_value->count;
-        ys = list_expr.value.integer_list_value->integers;
-        y_count = list_expr.value.integer_list_value->count;
-    }
-    else {
-        ys = variable.integer_list_value->integers;
-        y_count = variable.integer_list_value->count;
-        xs = list_expr.value.integer_list_value->integers;
-        x_count = list_expr.value.integer_list_value->count;
-    }
-#ifdef DEGA_1294
-    if (x_count == 1) {
-        return (d64binary_search(ys, y_count, xs[0]) == true);
-    }
-    if (x_count == 2) {
-        return (d64binary_search(ys, y_count, xs[0]) == true || d64binary_search(ys, y_count, xs[1]) == true);
-    }
-    if (x_count == 3) {
-        return (d64binary_search(ys, y_count, xs[0]) == true || d64binary_search(ys, y_count, xs[1]) == true || d64binary_search(ys, y_count, xs[2]) == true);
-    }
-#endif
-    size_t i = 0, j = 0;
-    while(i < x_count && j < y_count) {
-        int64_t x = xs[i];
-        int64_t y = ys[j];
-        if(x == y) {
-            return true;
-        }
-        if(y < x) {
-            j++;
-        }
-        else {
-            i++;
-        }
-    }
-    return false;
-}
-
-#endif
-
-
 static bool match_not_all_of_string(struct value variable, struct ast_list_expr list_expr)
 {
     struct string_value* xs;
@@ -731,8 +675,6 @@ static bool match_not_all_of_string(struct value variable, struct ast_list_expr 
     return false;
 }
 
-#ifdef DEGA_1468
-
 static bool match_all_of_int(struct value variable, struct ast_list_expr list_expr)
 {
     int64_t* xs = list_expr.value.integer_list_value->integers;
@@ -757,50 +699,6 @@ static bool match_all_of_int(struct value variable, struct ast_list_expr list_ex
     }
     return false;
 }
-
-#else
-
-static bool match_all_of_int(struct value variable, struct ast_list_expr list_expr)
-{
-    int64_t* xs = list_expr.value.integer_list_value->integers;
-    size_t x_count = list_expr.value.integer_list_value->count;
-    int64_t* ys = variable.integer_list_value->integers;
-    size_t y_count = variable.integer_list_value->count;
-    if(x_count <= y_count) {
-#ifdef DEGA_1294
-        if (x_count == 1) {
-            return (d64binary_search(ys, y_count, xs[0]) == true);
-        }
-        if (x_count == 2) {
-            return (d64binary_search(ys, y_count, xs[0]) == true && d64binary_search(ys, y_count, xs[1]) == true);
-        }
-        if (x_count == 3) {
-            return (d64binary_search(ys, y_count, xs[0]) == true && d64binary_search(ys, y_count, xs[1]) == true && d64binary_search(ys, y_count, xs[2]) == true);
-        }
-#endif
-        size_t i = 0, j = 0;
-        while(i < y_count && j < x_count) {
-            int64_t x = xs[j];
-            int64_t y = ys[i];
-            if(y < x) {
-                i++;
-            }
-            else if(x == y) {
-                i++;
-                j++;
-            }
-            else {
-                return false;
-            }
-        }
-        if(j < x_count) {
-            return false;
-        }
-        return true;
-    }
-    return false;
-}
-#endif
 
 static bool match_all_of_string(struct value variable, struct ast_list_expr list_expr)
 {

--- a/src/ast.c
+++ b/src/ast.c
@@ -588,11 +588,14 @@ static bool match_special_expr(
     }
 }
 
+// Returns index i; 0 <= i <= count. 
+// If x is among arr values returns index of element in arr with value equal to x
+// If there is not such element returns index i such that:
+//   if all elements in arr are less then x returns count (i.e the array's length)
+//   else returns i such that then arr[i-1] < x < arr[i]
 size_t next_low(const int64_t arr[], size_t low, size_t count, int64_t x)
 {
-//    assert(low <= high);
     size_t high = count - 1;
-    // Till low is less than high
     while (low < high) {
         size_t mid = low + (high - low) / 2;
         if (x <= arr[mid]) {
@@ -601,11 +604,9 @@ size_t next_low(const int64_t arr[], size_t low, size_t count, int64_t x)
             low = mid + 1;
         }
     }
-    // if x is greater than arr[low]
     if(low < count && arr[low] < x) {
        low++;
     }
- // Return the lower_bound index
  return low;
 }
 
@@ -631,6 +632,7 @@ static bool match_not_all_of_int(struct value variable, struct ast_list_expr lis
     while(i < x_count && from < y_count) {
         int64_t x = xs[i];
         from = next_low(ys, from, y_count, x);
+        // first check that new index is in array
         if(from < y_count && ys[from] == x) {
             return true;
         } else {

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -3,6 +3,8 @@ echo "Unit Tests"
 
 real_tests="build/tests/real_tests"
 
+log_file=/tmp/sky-test.log
+
 # Loop over compiled tests and run them.
 for test_file in build/tests/*_tests
 do
@@ -14,12 +16,14 @@ do
     if test -f $test_file
     then
         # Log execution to file.
-        if ./$test_file 2>&1 > /tmp/sky-test.log
+        if ./$test_file 2>&1 > $log_file
         then
-            rm -f /tmp/sky-test.log
+            echo 'no errors'
+            rm -f $log_file
         else
             # If error occurred then print off log.
-            cat /tmp/sky-test.log
+            echo "error in test; see $log_file"
+            cat $log_file
             exit 1
         fi
     fi


### PR DESCRIPTION
match_not_all_of_int and match__all_of_int optimization.

As it is shown in DEAG-1468 these two functions take at least 60% time of boolean expression evaluation. This optimization can considerably reduce timing, especially   in worst cases