### PR TITLE
Changes for Erlang Scheduler friendly implementation

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -398,6 +398,27 @@ static bool d64binary_search(const int64_t arr[], size_t count, int64_t to_find)
     return false;
 }
 
+static bool d64binary_search_counting(const int64_t arr[], size_t count, int64_t to_find,
+    int* ops_count)
+{
+    int imin = 0;
+    int imax = (int)count - 1;
+    while(imax >= imin) {
+        (*ops_count)++;
+        int imid = imin + ((imax - imin) / 2);
+        if(arr[imid] == to_find) {
+            return true;
+        }
+        if(arr[imid] < to_find) {
+            imin = imid + 1;
+        }
+        else {
+            imax = imid - 1;
+        }
+    }
+    return false;
+}
+
 static bool sbinary_search(struct string_value arr[], size_t count, betree_str_t to_find)
 {
     int imin = 0;
@@ -417,14 +438,47 @@ static bool sbinary_search(struct string_value arr[], size_t count, betree_str_t
     return false;
 }
 
+static bool sbinary_search_counting(struct string_value arr[], size_t count, betree_str_t to_find,
+    int* ops_count)
+{
+    int imin = 0;
+    int imax = (int)count - 1;
+    while(imax >= imin) {
+        (*ops_count)++;
+        int imid = imin + ((imax - imin) / 2);
+        if(arr[imid].str == to_find) {
+            return true;
+        }
+        if(arr[imid].str < to_find) {
+            imin = imid + 1;
+        }
+        else {
+            imax = imid - 1;
+        }
+    }
+    return false;
+}
+
 static bool integer_in_integer_list(int64_t integer, struct betree_integer_list* list)
 {
     return d64binary_search(list->integers, list->count, integer);
 }
 
+static bool integer_in_integer_list_counting(int64_t integer, struct betree_integer_list* list,
+    int* ops_count)
+{
+    return d64binary_search_counting(list->integers, list->count, integer, ops_count);
+}
+
 static bool string_in_string_list(struct string_value string, struct betree_string_list* list)
 {
     return sbinary_search(list->strings, list->count, string.str);
+}
+
+static bool string_in_string_list_counting(struct string_value string, struct betree_string_list* list,
+    int* ops_count)
+{
+    return sbinary_search_counting(list->strings, list->count, string.str, ops_count);
 }
 
 static bool compare_value_matches(enum ast_compare_value_e a, enum betree_value_type_e b)
@@ -588,6 +642,102 @@ static bool match_special_expr(
     }
 }
 
+static bool match_special_expr_counting(
+    const struct betree_variable** preds, const struct ast_special_expr special_expr,
+    int* ops_count)
+{
+    (*ops_count)++;
+    switch(special_expr.type) {
+        case AST_SPECIAL_FREQUENCY: {
+            switch(special_expr.frequency.op) {
+                case AST_SPECIAL_WITHINFREQUENCYCAP: {
+                    const struct ast_special_frequency* f = &special_expr.frequency;
+                    struct betree_frequency_caps* caps;
+                    bool is_caps_defined = get_frequency_var(f->attr_var.var, preds, &caps);
+                    if(is_caps_defined == false) {
+                        return false;
+                    }
+                    if(caps->size == 0) {
+                        // Optimization from looking at what within_frequency_caps does
+                        return true;
+                    }
+                    int64_t now;
+                    bool is_now_defined = get_integer_var(f->now.var, preds, &now);
+                    if(is_now_defined == false) {
+                        return false;
+                    }
+                    return within_frequency_caps_counting(
+                        caps, f->type, f->id, f->ns, f->value, f->length, now, ops_count);
+                }
+                default: abort();
+            }
+        }
+        case AST_SPECIAL_SEGMENT: {
+            const struct ast_special_segment* s = &special_expr.segment;
+            struct betree_segments* segments;
+            bool is_segment_defined = get_segments_var(s->attr_var.var, preds, &segments);
+            if(is_segment_defined == false) {
+                return false;
+            }
+            int64_t now;
+            bool is_now_defined = get_integer_var(s->now.var, preds, &now);
+            if(is_now_defined == false) {
+                return false;
+            }
+            switch(special_expr.segment.op) {
+                case AST_SPECIAL_SEGMENTWITHIN:
+                    return segment_within_counting(s->segment_id, s->seconds, segments, now,
+                        ops_count);
+                case AST_SPECIAL_SEGMENTBEFORE:
+                    return segment_before_counting(s->segment_id, s->seconds, segments, now,
+                        ops_count);
+                default: abort();
+            }
+        }
+        case AST_SPECIAL_GEO: {
+            switch(special_expr.geo.op) {
+                case AST_SPECIAL_GEOWITHINRADIUS: {
+                    const struct ast_special_geo* g = &special_expr.geo;
+                    double latitude_var, longitude_var;
+                    bool is_latitude_defined
+                        = get_float_var(g->latitude_var.var, preds, &latitude_var);
+                    bool is_longitude_defined
+                        = get_float_var(g->longitude_var.var, preds, &longitude_var);
+                    if(is_latitude_defined == false || is_longitude_defined == false) {
+                        return false;
+                    }
+
+                    (*ops_count)++;
+                    return geo_within_radius(
+                        g->latitude, g->longitude, latitude_var, longitude_var, g->radius);
+                }
+                default: abort();
+            }
+            return false;
+        }
+        case AST_SPECIAL_STRING: {
+            const struct ast_special_string* s = &special_expr.string;
+            struct string_value value;
+            bool is_string_defined = get_string_var(s->attr_var.var, preds, &value);
+            if(is_string_defined == false) {
+                return false;
+            }
+            (*ops_count)++;
+            switch(s->op) {
+                case AST_SPECIAL_CONTAINS:
+                    return contains(value.string, s->pattern);
+                case AST_SPECIAL_STARTSWITH:
+                    return starts_with(value.string, s->pattern);
+                case AST_SPECIAL_ENDSWITH:
+                    return ends_with(value.string, s->pattern);
+                default: abort();
+            }
+            return false;
+        }
+        default: abort();
+    }
+}
+
 // Returns index i; 0 <= i <= count. 
 // If x is among arr values returns index of element in arr with value equal to x
 // If there is not such element returns index i such that:
@@ -642,6 +792,41 @@ static bool match_not_all_of_int(struct value variable, struct ast_list_expr lis
     return false;
 }
 
+static bool match_not_all_of_int_counting(struct value variable, struct ast_list_expr list_expr,
+    int* ops_count)
+{
+    (*ops_count)++;
+    int64_t* xs;
+    size_t x_count;
+    int64_t* ys;
+    size_t y_count;
+    if(variable.integer_list_value->count < list_expr.value.integer_list_value->count) {
+        xs = variable.integer_list_value->integers;
+        x_count = variable.integer_list_value->count;
+        ys = list_expr.value.integer_list_value->integers;
+        y_count = list_expr.value.integer_list_value->count;
+    }
+    else {
+        ys = variable.integer_list_value->integers;
+        y_count = variable.integer_list_value->count;
+        xs = list_expr.value.integer_list_value->integers;
+        x_count = list_expr.value.integer_list_value->count;
+    }
+    size_t i = 0, from = 0;
+    while(i < x_count && from < y_count) {
+        (*ops_count)++;
+        int64_t x = xs[i];
+        from = next_low(ys, from, y_count, x);
+        // first check that new index is in array
+        if(from < y_count && ys[from] == x) {
+            return true;
+        } else {
+            i++;
+        }
+    }
+    return false;
+}
+
 static bool match_not_all_of_string(struct value variable, struct ast_list_expr list_expr)
 {
     struct string_value* xs;
@@ -662,6 +847,44 @@ static bool match_not_all_of_string(struct value variable, struct ast_list_expr 
     }
     size_t i = 0, j = 0;
     while(i < x_count && j < y_count) {
+        struct string_value* x = &xs[i];
+        struct string_value* y = &ys[j];
+        if(x->str == y->str) {
+            return true;
+        }
+        if(y->str < x->str) {
+            j++;
+        }
+        else {
+            i++;
+        }
+    }
+    return false;
+}
+
+static bool match_not_all_of_string_counting(struct value variable, struct ast_list_expr list_expr,
+    int* ops_count)
+{
+    (*ops_count)++;
+    struct string_value* xs;
+    size_t x_count;
+    struct string_value* ys;
+    size_t y_count;
+    if(variable.string_list_value->count < list_expr.value.integer_list_value->count) {
+        xs = variable.string_list_value->strings;
+        x_count = variable.string_list_value->count;
+        ys = list_expr.value.string_list_value->strings;
+        y_count = list_expr.value.integer_list_value->count;
+    }
+    else {
+        ys = variable.string_list_value->strings;
+        y_count = variable.string_list_value->count;
+        xs = list_expr.value.string_list_value->strings;
+        x_count = list_expr.value.integer_list_value->count;
+    }
+    size_t i = 0, j = 0;
+    while(i < x_count && j < y_count) {
+        (*ops_count)++;
         struct string_value* x = &xs[i];
         struct string_value* y = &ys[j];
         if(x->str == y->str) {
@@ -702,6 +925,34 @@ static bool match_all_of_int(struct value variable, struct ast_list_expr list_ex
     return false;
 }
 
+static bool match_all_of_int_counting(struct value variable, struct ast_list_expr list_expr,
+    int* ops_count)
+{
+    (*ops_count)++;
+    int64_t* xs = list_expr.value.integer_list_value->integers;
+    size_t x_count = list_expr.value.integer_list_value->count;
+    int64_t* ys = variable.integer_list_value->integers;
+    size_t y_count = variable.integer_list_value->count;
+    if(x_count <= y_count) {
+        size_t from = 0, j = 0;
+        while(from < y_count && j < x_count) {
+            (*ops_count)++;
+            int64_t x = xs[j];
+            from = next_low(ys, from, y_count, x);
+            if(from < y_count && ys[from] == x) {
+                j++;
+            } else {
+                return false;
+            }
+        }
+        if(j < x_count) {
+            return false;
+        }
+        return true;
+    }
+    return false;
+}
+
 static bool match_all_of_string(struct value variable, struct ast_list_expr list_expr)
 {
     struct string_value* xs = list_expr.value.string_list_value->strings;
@@ -711,6 +962,39 @@ static bool match_all_of_string(struct value variable, struct ast_list_expr list
     if(x_count <= y_count) {
         size_t i = 0, j = 0;
         while(i < y_count && j < x_count) {
+            struct string_value* x = &xs[j];
+            struct string_value* y = &ys[i];
+            if(y->str < x->str) {
+                i++;
+            }
+            else if(x->str == y->str) {
+                i++;
+                j++;
+            }
+            else {
+                return false;
+            }
+        }
+        if(j < x_count) {
+            return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+static bool match_all_of_string_counting(struct value variable, struct ast_list_expr list_expr,
+    int* ops_count)
+{
+    (*ops_count)++;
+    struct string_value* xs = list_expr.value.string_list_value->strings;
+    size_t x_count = list_expr.value.string_list_value->count;
+    struct string_value* ys = variable.string_list_value->strings;
+    size_t y_count = variable.string_list_value->count;
+    if(x_count <= y_count) {
+        size_t i = 0, j = 0;
+        while(i < y_count && j < x_count) {
+            (*ops_count)++;
             struct string_value* x = &xs[j];
             struct string_value* y = &ys[i];
             if(y->str < x->str) {
@@ -778,6 +1062,54 @@ static bool match_list_expr(
     }
 }
 
+static bool match_list_expr_counting(
+    const struct betree_variable** preds, const struct ast_list_expr list_expr,
+    int* ops_count)
+{
+    (*ops_count)++;
+    struct value variable;
+    bool is_variable_defined = get_variable(list_expr.attr_var.var, preds, &variable);
+    if(is_variable_defined == false) {
+        return false;
+    }
+    switch(list_expr.op) {
+        case AST_LIST_ONE_OF:
+        case AST_LIST_NONE_OF: {
+            bool result = false;
+            switch(list_expr.value.value_type) {
+                case AST_LIST_VALUE_INTEGER_LIST:
+                    result = match_not_all_of_int_counting(variable, list_expr, ops_count);
+                    break;
+                case AST_LIST_VALUE_STRING_LIST: {
+                    result = match_not_all_of_string_counting(variable, list_expr, ops_count);
+                    break;
+                }
+                default: abort();
+            }
+            switch(list_expr.op) {
+                case AST_LIST_ONE_OF:
+                    return result;
+                case AST_LIST_NONE_OF:
+                    return !result;
+                case AST_LIST_ALL_OF:
+                    invalid_expr("Should never happen");
+                    return false;
+                default: abort();
+            }
+        }
+        case AST_LIST_ALL_OF: {
+            switch(list_expr.value.value_type) {
+                case AST_LIST_VALUE_INTEGER_LIST:
+                    return match_all_of_int_counting(variable, list_expr, ops_count);
+                case AST_LIST_VALUE_STRING_LIST:
+                    return match_all_of_string_counting(variable, list_expr, ops_count);
+                default: abort();
+            }
+        }
+        default: abort();
+    }
+}
+
 static bool match_set_expr(const struct betree_variable** preds, const struct ast_set_expr set_expr)
 {
     struct set_left_value left = set_expr.left_value;
@@ -818,6 +1150,64 @@ static bool match_set_expr(const struct betree_variable** preds, const struct as
             return false;
         }
         is_in = string_in_string_list(variable, right.string_list_value);
+    }
+    else {
+        invalid_expr("invalid set expression");
+        return false;
+    }
+    switch(set_expr.op) {
+        case AST_SET_NOT_IN: {
+            return !is_in;
+        }
+        case AST_SET_IN: {
+            return is_in;
+        }
+        default: abort();
+    }
+}
+
+static bool match_set_expr_counting(const struct betree_variable** preds, const struct ast_set_expr set_expr,
+    int* ops_count)
+{
+    (*ops_count)++;
+    struct set_left_value left = set_expr.left_value;
+    struct set_right_value right = set_expr.right_value;
+    bool is_in;
+    if(left.value_type == AST_SET_LEFT_VALUE_INTEGER
+        && right.value_type == AST_SET_RIGHT_VALUE_VARIABLE) {
+        struct betree_integer_list* variable;
+        bool is_variable_defined = get_integer_list_var(right.variable_value.var, preds, &variable);
+        if(is_variable_defined == false) {
+            return false;
+        }
+        is_in = integer_in_integer_list_counting(left.integer_value, variable, ops_count);
+    }
+    else if(left.value_type == AST_SET_LEFT_VALUE_STRING
+        && right.value_type == AST_SET_RIGHT_VALUE_VARIABLE) {
+        struct betree_string_list* variable;
+        bool is_variable_defined = get_string_list_var(right.variable_value.var, preds, &variable);
+        if(is_variable_defined == false) {
+            return false;
+        }
+        is_in = string_in_string_list_counting(left.string_value, variable, ops_count);
+    }
+    else if(left.value_type == AST_SET_LEFT_VALUE_VARIABLE
+        && right.value_type == AST_SET_RIGHT_VALUE_INTEGER_LIST) {
+        int64_t variable;
+        bool is_variable_defined = get_integer_var(left.variable_value.var, preds, &variable);
+        if(is_variable_defined == false) {
+            return false;
+        }
+        is_in = integer_in_integer_list_counting(variable, right.integer_list_value, ops_count);
+    }
+    else if(left.value_type == AST_SET_LEFT_VALUE_VARIABLE
+        && right.value_type == AST_SET_RIGHT_VALUE_STRING_LIST) {
+        struct string_value variable;
+        bool is_variable_defined = get_string_var(left.variable_value.var, preds, &variable);
+        if(is_variable_defined == false) {
+            return false;
+        }
+        is_in = string_in_string_list_counting(variable, right.string_list_value, ops_count);
     }
     else {
         invalid_expr("invalid set expression");
@@ -999,6 +1389,47 @@ static bool match_bool_expr(const struct betree_variable** preds,
     }
 }
 
+static bool match_bool_expr_counting(const struct betree_variable** preds,
+    const struct ast_bool_expr bool_expr,
+    struct memoize* memoize,
+    struct report_counting* report)
+{
+    report->ops_count++;
+    switch(bool_expr.op) {
+        case AST_BOOL_LITERAL:
+            return bool_expr.literal;
+        case AST_BOOL_AND: {
+            bool lhs = match_node_counting(preds, bool_expr.binary.lhs, memoize, report);
+            if(lhs == false) {
+                return false;
+            }
+            bool rhs = match_node_counting(preds, bool_expr.binary.rhs, memoize, report);
+            return rhs;
+        }
+        case AST_BOOL_OR: {
+            bool lhs = match_node_counting(preds, bool_expr.binary.lhs, memoize, report);
+            if(lhs == true) {
+                return true;
+            }
+            bool rhs = match_node_counting(preds, bool_expr.binary.rhs, memoize, report);
+            return rhs;
+        }
+        case AST_BOOL_NOT: {
+            bool result = match_node_counting(preds, bool_expr.unary.expr, memoize, report);
+            return !result;
+        }
+        case AST_BOOL_VARIABLE: {
+            bool value;
+            bool is_variable_defined = get_bool_var(bool_expr.variable.var, preds, &value);
+            if(is_variable_defined == false) {
+                return false;
+            }
+            return value;
+        }
+        default: abort();
+    }
+}
+
 static bool match_is_null_expr(const struct betree_variable** preds,
     const struct ast_is_null_expr is_null_expr)
 {
@@ -1060,6 +1491,71 @@ static bool match_node_inner(const struct betree_variable** preds,
             break;
         }
         case AST_TYPE_EQUALITY_EXPR: {
+            result = match_equality_expr(preds, node->equality_expr);
+            break;
+        }
+        default: abort();
+    }
+    if(node->memoize_id != INVALID_PRED) {
+        if(result) {
+            set_bit(memoize->pass, node->memoize_id);
+        }
+        else {
+            set_bit(memoize->fail, node->memoize_id);
+        }
+    }
+    return result;
+}
+
+bool match_node_counting(const struct betree_variable** preds,
+    const struct ast_node* node,
+    struct memoize* memoize,
+    struct report_counting* report)
+{
+    report->node_count++;
+    if(node->memoize_id != INVALID_PRED) {
+        if(test_bit(memoize->pass, node->memoize_id)) {
+            if(report != NULL) {
+                report->memoized++;
+            }
+            return true;
+        }
+        if(test_bit(memoize->fail, node->memoize_id)) {
+            if(report != NULL) {
+                report->memoized++;
+            }
+            return false;
+        }
+    }
+    bool result;
+    switch(node->type) {
+        case AST_TYPE_IS_NULL_EXPR:
+            report->ops_count++;
+            result = match_is_null_expr(preds, node->is_null_expr);
+            break;
+        case AST_TYPE_SPECIAL_EXPR: {
+            result = match_special_expr_counting(preds, node->special_expr, &report->ops_count);
+            break;
+        }
+        case AST_TYPE_BOOL_EXPR: {
+            result = match_bool_expr_counting(preds, node->bool_expr, memoize, report);
+            break;
+        }
+        case AST_TYPE_LIST_EXPR: {
+            result = match_list_expr_counting(preds, node->list_expr, &report->ops_count);
+            break;
+        }
+        case AST_TYPE_SET_EXPR: {
+            result = match_set_expr_counting(preds, node->set_expr, &report->ops_count);
+            break;
+        }
+        case AST_TYPE_COMPARE_EXPR: {
+            report->ops_count++;
+            result = match_compare_expr(preds, node->compare_expr);
+            break;
+        }
+        case AST_TYPE_EQUALITY_EXPR: {
+            report->ops_count++;
             result = match_equality_expr(preds, node->equality_expr);
             break;
         }

--- a/src/ast.h
+++ b/src/ast.h
@@ -324,6 +324,11 @@ bool match_node(const struct betree_variable** preds,
     struct memoize* memoize,
     struct report* report);
 
+bool match_node_counting(const struct betree_variable** preds,
+    const struct ast_node* node,
+    struct memoize* memoize,
+    struct report_counting* report);
+
 struct value_bound get_variable_bound(
     const struct attr_domain* domain, const struct ast_node* node);
 

--- a/src/betree.c
+++ b/src/betree.c
@@ -545,7 +545,7 @@ bool betree_insert(struct betree* tree, betree_sub_t id, const char* expr)
     return betree_insert_with_constants(tree, id, 0, NULL, expr);
 }
 
-static const struct betree_variable** make_environment(size_t attr_domain_count, const struct betree_event* event)
+const struct betree_variable** make_environment(size_t attr_domain_count, const struct betree_event* event)
 {
     const struct betree_variable** preds = bcalloc(attr_domain_count * sizeof(*preds));
     for(size_t i = 0; i < event->variable_count; i++) {
@@ -619,6 +619,29 @@ struct report* make_report()
 }
 
 void free_report(struct report* report)
+{
+    bfree(report->subs);
+    bfree(report);
+}
+
+struct report_counting* make_report_counting()
+{
+    struct report_counting* report = bcalloc(sizeof(*report));
+    if(report == NULL) {
+        fprintf(stderr, "%s bcalloc failed\n", __func__);
+        abort();
+    }
+    report->evaluated = 0;
+    report->matched = 0;
+    report->memoized = 0;
+    report->shorted = 0;
+    report->subs = NULL;
+    report->node_count = 0;
+    report->ops_count = 0;
+    return report;
+}
+
+void free_report_counting(struct report_counting* report)
 {
     bfree(report->subs);
     bfree(report);

--- a/src/betree.h
+++ b/src/betree.h
@@ -22,6 +22,16 @@ struct report {
     betree_sub_t* subs;
 };
 
+struct report_counting {
+    size_t evaluated;
+    size_t matched;
+    size_t memoized;
+    size_t shorted;
+    betree_sub_t* subs;
+    int node_count;
+    int ops_count;
+};
+
 struct betree_sub;
 struct betree_constant;
 struct betree_variable;
@@ -72,6 +82,8 @@ struct betree_variable_definition {
     const char* name;
     enum betree_value_type_e type;
 };
+
+const struct betree_variable** make_environment(size_t attr_domain_count, const struct betree_event* event);
 
 /*
  * Initialization
@@ -128,6 +140,9 @@ bool betree_exists_with_event(const struct betree* betree, struct betree_event* 
 
 struct report* make_report();
 void free_report(struct report* report);
+
+struct report_counting* make_report_counting();
+void free_report_counting(struct report_counting* report);
 
 /*
  * Destruction

--- a/src/special.h
+++ b/src/special.h
@@ -13,10 +13,23 @@ bool within_frequency_caps(const struct betree_frequency_caps* caps,
     uint32_t value,
     size_t length,
     int64_t now);
+bool within_frequency_caps_counting(const struct betree_frequency_caps* caps,
+    enum frequency_type_e type,
+    uint32_t id,
+    const struct string_value namespace,
+    uint32_t value,
+    size_t length,
+    int64_t now, int* ops_count);
 bool segment_within(
     int64_t segment_id, int32_t after_seconds, const struct betree_segments* segments, int64_t now);
+bool segment_within_counting(
+    int64_t segment_id, int32_t after_seconds, const struct betree_segments* segments, int64_t now,
+    int* ops_count);
 bool segment_before(
     int64_t segment_id, int32_t before_seconds, const struct betree_segments* segments, int64_t now);
+bool segment_before_counting(
+    int64_t segment_id, int32_t before_seconds, const struct betree_segments* segments, int64_t now,
+    int* ops_count);
 bool geo_within_radius(double lat1, double lon1, double lat2, double lon2, double distance);
 bool contains(const char* value, const char* pattern);
 bool starts_with(const char* value, const char* pattern);

--- a/src/tree.c
+++ b/src/tree.c
@@ -18,15 +18,16 @@
 #include "tree.h"
 #include "utils.h"
 
-struct subs_to_eval {
-    struct betree_sub** subs;
-    size_t capacity;
-    size_t count;
-};
-
-static void init_subs_to_eval(struct subs_to_eval* subs)
+void init_subs_to_eval(struct subs_to_eval* subs)
 {
     size_t init = 10;
+    subs->subs = bmalloc(init * sizeof(*subs->subs));
+    subs->capacity = init;
+    subs->count = 0;
+}
+
+void init_subs_to_eval_ext(struct subs_to_eval* subs, size_t init)
+{
     subs->subs = bmalloc(init * sizeof(*subs->subs));
     subs->capacity = init;
     subs->count = 0;
@@ -62,7 +63,7 @@ static enum short_circuit_e try_short_circuit(size_t attr_domains_count,
     return SHORT_CIRCUIT_NONE;
 }
 
-static bool match_sub(size_t attr_domains_count,
+bool match_sub(size_t attr_domains_count,
     const struct betree_variable** preds,
     const struct betree_sub* sub,
     struct report* report,
@@ -85,11 +86,43 @@ static bool match_sub(size_t attr_domains_count,
     return result;
 }
 
+bool match_sub_counting(size_t attr_domains_count,
+    const struct betree_variable** preds,
+    const struct betree_sub* sub,
+    struct report_counting* report,
+    struct memoize* memoize,
+    const uint64_t* undefined)
+{
+    enum short_circuit_e short_circuit = try_short_circuit(attr_domains_count, &sub->short_circuit, undefined);
+    if(short_circuit != SHORT_CIRCUIT_NONE) {
+        if(report != NULL) {
+            report->shorted++;
+        }
+        if(short_circuit == SHORT_CIRCUIT_PASS) {
+            return true;
+        }
+        if(short_circuit == SHORT_CIRCUIT_FAIL) {
+            return false;
+        }
+    }
+    bool result = match_node_counting(preds, sub->expr, memoize, report);
+    return result;
+}
+
 static void check_sub(const struct lnode* lnode, struct subs_to_eval* subs)
 {
     for(size_t i = 0; i < lnode->sub_count; i++) {
         struct betree_sub* sub = lnode->subs[i];
         add_sub_to_eval(sub, subs);
+    }
+}
+
+static void check_sub_node_counting(const struct lnode* lnode, struct subs_to_eval* subs, int* node_count)
+{
+    for(size_t i = 0; i < lnode->sub_count; i++) {
+        struct betree_sub* sub = lnode->subs[i];
+        add_sub_to_eval(sub, subs);
+        ++*node_count;
     }
 }
 
@@ -112,12 +145,17 @@ static void search_cdir(const struct attr_domain** attr_domains,
     struct cdir* cdir,
     struct subs_to_eval* subs, bool open_left, bool open_right);
 
+static void search_cdir_node_counting(const struct attr_domain** attr_domains,
+    const struct betree_variable** preds,
+    struct cdir* cdir,
+    struct subs_to_eval* subs, bool open_left, bool open_right, int* node_count);
+
 static bool event_contains_variable(const struct betree_variable** preds, betree_var_t variable_id)
 {
     return preds[variable_id] != NULL;
 }
 
-static void match_be_tree(const struct attr_domain** attr_domains,
+void match_be_tree(const struct attr_domain** attr_domains,
     const struct betree_variable** preds,
     const struct cnode* cnode,
     struct subs_to_eval* subs)
@@ -133,6 +171,27 @@ static void match_be_tree(const struct attr_domain** attr_domains,
                 search_cdir(attr_domains, preds, pnode->cdir, subs, true, true);
             }
         }
+    }
+}
+
+void match_be_tree_node_counting(const struct attr_domain** attr_domains,
+    const struct betree_variable** preds,
+    const struct cnode* cnode,
+    struct subs_to_eval* subs, int* node_count)
+{
+    check_sub_node_counting(cnode->lnode, subs, node_count);
+    if(cnode->pdir != NULL) {
+        for(size_t i = 0; i < cnode->pdir->pnode_count; i++) {
+            struct pnode* pnode = cnode->pdir->pnodes[i];
+            const struct attr_domain* attr_domain
+                = get_attr_domain(attr_domains, pnode->attr_var.var);
+            if(attr_domain->allow_undefined
+                || event_contains_variable(preds, pnode->attr_var.var)) {
+                search_cdir_node_counting(attr_domains, preds, pnode->cdir, subs, true, true, node_count);
+            }
+            ++*node_count;
+        }
+        ++*node_count;
     }
 }
 
@@ -237,6 +296,20 @@ static void search_cdir(const struct attr_domain** attr_domains,
     }
     if(is_event_enclosed(preds, cdir->rchild, false, open_right)) {
         search_cdir(attr_domains, preds, cdir->rchild, subs, false, open_right);
+    }
+}
+
+static void search_cdir_node_counting(const struct attr_domain** attr_domains,
+    const struct betree_variable** preds,
+    struct cdir* cdir,
+    struct subs_to_eval* subs, bool open_left, bool open_right, int* node_count)
+{
+    match_be_tree_node_counting(attr_domains, preds, cdir->cnode, subs, node_count);
+    if(is_event_enclosed(preds, cdir->lchild, open_left, false)) {
+        search_cdir_node_counting(attr_domains, preds, cdir->lchild, subs, open_left, false, node_count);
+    }
+    if(is_event_enclosed(preds, cdir->rchild, false, open_right)) {
+        search_cdir_node_counting(attr_domains, preds, cdir->rchild, subs, false, open_right, node_count);
     }
 }
 
@@ -1706,6 +1779,16 @@ struct memoize make_memoize(size_t pred_count)
     return memoize;
 }
 
+struct memoize make_memoize_with_count(size_t pred_count, size_t* count)
+{
+    *count = pred_count / 64 + 1;
+    struct memoize memoize = {
+        .pass = bcalloc(*count * sizeof(*memoize.pass)),
+        .fail = bcalloc(*count * sizeof(*memoize.fail)),
+    };
+    return memoize;
+}
+
 void free_memoize(struct memoize memoize)
 {
     bfree(memoize.pass);
@@ -1724,7 +1807,41 @@ static uint64_t* make_undefined(size_t attr_domain_count, const struct betree_va
     return undefined;
 }
 
+uint64_t* make_undefined_with_count(size_t attr_domain_count, const struct betree_variable** preds, size_t* count)
+{
+    *count = attr_domain_count / 64 + 1;
+    uint64_t* undefined = bcalloc(*count * sizeof(*undefined));
+    for(size_t i = 0; i < attr_domain_count; i++) {
+        if(preds[i] == NULL) {
+            set_bit(undefined, i);
+        }
+    }
+    return undefined;
+}
+
 static void add_sub(betree_sub_t id, struct report* report)
+{
+    if(report->matched == 0) {
+        report->subs = bcalloc(sizeof(*report->subs));
+        if(report->subs == NULL) {
+            fprintf(stderr, "%s bcalloc failed", __func__);
+            abort();
+        }
+    }
+    else {
+        betree_sub_t* subs
+            = brealloc(report->subs, sizeof(*report->subs) * (report->matched + 1));
+        if(subs == NULL) {
+            fprintf(stderr, "%s brealloc failed", __func__);
+            abort();
+        }
+        report->subs = subs;
+    }
+    report->subs[report->matched] = id;
+    report->matched++;
+}
+
+void add_sub_counting(betree_sub_t id, struct report_counting* report)
 {
     if(report->matched == 0) {
         report->subs = bcalloc(sizeof(*report->subs));

--- a/src/tree.h
+++ b/src/tree.h
@@ -83,6 +83,38 @@ struct pdir {
     };
 };
 
+struct subs_to_eval {
+    struct betree_sub** subs;
+    size_t capacity;
+    size_t count;
+};
+
+void init_subs_to_eval(struct subs_to_eval* subs);
+void init_subs_to_eval_ext(struct subs_to_eval* subs, size_t init);
+uint64_t* make_undefined_with_count(size_t attr_domain_count, const struct betree_variable** preds, size_t* count);
+struct memoize make_memoize_with_count(size_t pred_count, size_t* count);
+void match_be_tree(const struct attr_domain** attr_domains,
+    const struct betree_variable** preds,
+    const struct cnode* cnode,
+    struct subs_to_eval* subs);
+void match_be_tree_node_counting(const struct attr_domain** attr_domains,
+    const struct betree_variable** preds,
+    const struct cnode* cnode,
+    struct subs_to_eval* subs, int* node_count);
+bool match_sub(size_t attr_domains_count,
+    const struct betree_variable** preds,
+    const struct betree_sub* sub,
+    struct report* report,
+    struct memoize* memoize,
+    const uint64_t* undefined);
+bool match_sub_counting(size_t attr_domains_count,
+    const struct betree_variable** preds,
+    const struct betree_sub* sub,
+    struct report_counting* report,
+    struct memoize* memoize,
+    const uint64_t* undefined);
+void add_sub_counting(betree_sub_t id, struct report_counting* report);
+
 void free_sub(struct betree_sub* sub);
 void free_event(struct betree_event* event);
 


### PR DESCRIPTION
Commit extends `be-tree` library with functions that:
- count number of visited nodes when traversing BE-Tree;
- count number of visited nodes when traversing boolean expressions ASTs;
- count number of boolean expressions operations.

The nodes counts and operations counts will be used by `erl-be-tree` to estimate number of reductions consumed when event match against boolean expressions is performed.