### PR TITLE
Fix: the clustering for expressions that contain 'not (A and B)', 'not (A or B)'

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -1589,6 +1589,206 @@ static void get_variable_bound_inner(const struct attr_domain* domain,
     const struct ast_node* node,
     struct value_bound* bound,
     bool is_reversed,
+    struct bound_dirty* dirty);
+
+static void get_variable_bound_ast_bool_or(const struct attr_domain* domain,
+    const struct ast_node* node,
+    struct value_bound* bound,
+    bool is_reversed,
+    struct bound_dirty* dirty)
+{
+    struct value_bound lbound = { .value_type = bound->value_type };
+    struct bound_dirty ldirty = { .min_dirty = false, .max_dirty = false };
+    struct value_bound rbound = { .value_type = bound->value_type };
+    struct bound_dirty rdirty = { .min_dirty = false, .max_dirty = false };
+    get_variable_bound_inner(
+        domain, node->bool_expr.binary.lhs, &lbound, is_reversed, &ldirty);
+    get_variable_bound_inner(
+        domain, node->bool_expr.binary.rhs, &rbound, is_reversed, &rdirty);
+    if(ldirty.min_dirty == true && rdirty.min_dirty == true) {
+        dirty->min_dirty = true;
+        switch(bound->value_type) {
+            case BETREE_BOOLEAN:
+                bound->bmin = lbound.bmin && rbound.bmin;
+                break;
+            case BETREE_INTEGER:
+            case BETREE_INTEGER_LIST:
+                bound->imin = d64min(lbound.imin, rbound.imin);
+                break;
+            case BETREE_FLOAT:
+                bound->fmin = fmin(lbound.fmin, rbound.fmin);
+                break;
+            case BETREE_STRING:
+            case BETREE_STRING_LIST:
+            case BETREE_INTEGER_ENUM:
+                bound->smin = smin(lbound.smin, rbound.smin);
+                break;
+            case BETREE_SEGMENTS:
+            case BETREE_FREQUENCY_CAPS:
+            default:
+                break;
+        }
+    }
+    if(ldirty.max_dirty == true && rdirty.max_dirty == true) {
+        dirty->max_dirty = true;
+        switch(bound->value_type) {
+            case BETREE_BOOLEAN:
+                bound->bmax = lbound.bmax || rbound.bmax;
+                break;
+            case BETREE_INTEGER:
+            case BETREE_INTEGER_LIST:
+                bound->imax = d64max(lbound.imax, rbound.imax);
+                break;
+            case BETREE_FLOAT:
+                bound->fmax = fmax(lbound.fmax, rbound.fmax);
+                break;
+            case BETREE_STRING:
+            case BETREE_STRING_LIST:
+            case BETREE_INTEGER_ENUM:
+                bound->smax = smax(lbound.smax, rbound.smax);
+                break;
+            case BETREE_SEGMENTS:
+            case BETREE_FREQUENCY_CAPS:
+            default:
+                break;
+        }
+    }
+    return;
+}
+
+static void get_variable_bound_ast_bool_and(const struct attr_domain* domain,
+    const struct ast_node* node,
+    struct value_bound* bound,
+    bool is_reversed,
+    struct bound_dirty* dirty)
+{
+    struct value_bound lbound = { .value_type = bound->value_type };
+    struct bound_dirty ldirty = { .min_dirty = false, .max_dirty = false };
+    struct value_bound rbound = { .value_type = bound->value_type };
+    struct bound_dirty rdirty = { .min_dirty = false, .max_dirty = false };
+    get_variable_bound_inner(
+        domain, node->bool_expr.binary.lhs, &lbound, is_reversed, &ldirty);
+    get_variable_bound_inner(
+        domain, node->bool_expr.binary.rhs, &rbound, is_reversed, &rdirty);
+    if(ldirty.min_dirty == true || rdirty.min_dirty == true) {
+        dirty->min_dirty = true;
+        switch(bound->value_type) {
+            case BETREE_BOOLEAN:
+                if(ldirty.min_dirty == true && rdirty.min_dirty == true) {
+                    bound->bmin = lbound.bmin && rbound.bmin;
+                }
+                else if(ldirty.min_dirty == true) {
+                    bound->bmin = lbound.bmin;
+                }
+                else {
+                    bound->bmin = rbound.bmin;
+                }
+                break;
+            case BETREE_INTEGER:
+            case BETREE_INTEGER_LIST:
+                if(ldirty.min_dirty == true && rdirty.min_dirty == true) {
+                    bound->imin = d64min(lbound.imin, rbound.imin);
+                }
+                else if(ldirty.min_dirty == true) {
+                    bound->imin = lbound.imin;
+                }
+                else {
+                    bound->imin = rbound.imin;
+                }
+                break;
+            case BETREE_FLOAT:
+                if(ldirty.min_dirty == true && rdirty.min_dirty == true) {
+                    bound->fmin = fmin(lbound.fmin, rbound.fmin);
+                }
+                else if(ldirty.min_dirty == true) {
+                    bound->fmin = lbound.fmin;
+                }
+                else {
+                    bound->fmin = rbound.fmin;
+                }
+                break;
+            case BETREE_STRING:
+            case BETREE_STRING_LIST:
+            case BETREE_INTEGER_ENUM:
+                if(ldirty.min_dirty == true && rdirty.min_dirty == true) {
+                    bound->smin = smin(lbound.smin, rbound.smin);
+                }
+                else if(ldirty.min_dirty == true) {
+                    bound->smin = lbound.smin;
+                }
+                else {
+                    bound->smin = rbound.smin;
+                }
+                break;
+            case BETREE_SEGMENTS:
+            case BETREE_FREQUENCY_CAPS:
+            default:
+                break;
+        }
+    }
+    if(ldirty.max_dirty == true || rdirty.max_dirty == true) {
+        dirty->max_dirty = true;
+        switch(bound->value_type) {
+            case BETREE_BOOLEAN:
+                if(ldirty.max_dirty == true && rdirty.max_dirty == true) {
+                    bound->bmax = lbound.bmax || rbound.bmax;
+                }
+                else if(ldirty.max_dirty == true) {
+                    bound->bmax = lbound.bmax;
+                }
+                else {
+                    bound->bmax = rbound.bmax;
+                }
+                break;
+            case BETREE_INTEGER:
+            case BETREE_INTEGER_LIST:
+                if(ldirty.max_dirty == true && rdirty.max_dirty == true) {
+                    bound->imax = d64max(lbound.imax, rbound.imax);
+                }
+                else if(ldirty.max_dirty == true) {
+                    bound->imax = lbound.imax;
+                }
+                else {
+                    bound->imax = rbound.imax;
+                }
+                break;
+            case BETREE_FLOAT:
+                if(ldirty.max_dirty == true && rdirty.max_dirty == true) {
+                    bound->fmax = fmax(lbound.fmax, rbound.fmax);
+                }
+                else if(ldirty.max_dirty == true) {
+                    bound->fmax = lbound.fmax;
+                }
+                else {
+                    bound->fmax = rbound.fmax;
+                }
+                break;
+            case BETREE_STRING:
+            case BETREE_STRING_LIST:
+            case BETREE_INTEGER_ENUM:
+                if(ldirty.max_dirty == true && rdirty.max_dirty == true) {
+                    bound->smax = smax(lbound.smax, rbound.smax);
+                }
+                else if(ldirty.max_dirty == true) {
+                    bound->smax = lbound.smax;
+                }
+                else {
+                    bound->smax = rbound.smax;
+                }
+                break;
+            case BETREE_SEGMENTS:
+            case BETREE_FREQUENCY_CAPS:
+            default:
+                break;
+        }
+    }
+    return;
+}
+
+static void get_variable_bound_inner(const struct attr_domain* domain,
+    const struct ast_node* node,
+    struct value_bound* bound,
+    bool is_reversed,
     struct bound_dirty* dirty)
 {
     if(node == NULL) {
@@ -1918,184 +2118,18 @@ static void get_variable_bound_inner(const struct attr_domain* domain,
                         domain, node->bool_expr.unary.expr, bound, !is_reversed, dirty);
                     return;
                 case AST_BOOL_OR: {
-                    struct value_bound lbound = { .value_type = bound->value_type };
-                    struct bound_dirty ldirty = { .min_dirty = false, .max_dirty = false };
-                    struct value_bound rbound = { .value_type = bound->value_type };
-                    struct bound_dirty rdirty = { .min_dirty = false, .max_dirty = false };
-                    get_variable_bound_inner(
-                        domain, node->bool_expr.binary.lhs, &lbound, is_reversed, &ldirty);
-                    get_variable_bound_inner(
-                        domain, node->bool_expr.binary.rhs, &rbound, is_reversed, &rdirty);
-                    if(ldirty.min_dirty == true && rdirty.min_dirty == true) {
-                        dirty->min_dirty = true;
-                        switch(bound->value_type) {
-                            case BETREE_BOOLEAN:
-                                bound->bmin = lbound.bmin && rbound.bmin;
-                                break;
-                            case BETREE_INTEGER:
-                            case BETREE_INTEGER_LIST:
-                                bound->imin = d64min(lbound.imin, rbound.imin);
-                                break;
-                            case BETREE_FLOAT:
-                                bound->fmin = fmin(lbound.fmin, rbound.fmin);
-                                break;
-                            case BETREE_STRING:
-                            case BETREE_STRING_LIST:
-                            case BETREE_INTEGER_ENUM:
-                                bound->smin = smin(lbound.smin, rbound.smin);
-                                break;
-                            case BETREE_SEGMENTS:
-                            case BETREE_FREQUENCY_CAPS:
-                            default:
-                                break;
-                        }
-                    }
-                    if(ldirty.max_dirty == true && rdirty.max_dirty == true) {
-                        dirty->max_dirty = true;
-                        switch(bound->value_type) {
-                            case BETREE_BOOLEAN:
-                                bound->bmax = lbound.bmax || rbound.bmax;
-                                break;
-                            case BETREE_INTEGER:
-                            case BETREE_INTEGER_LIST:
-                                bound->imax = d64max(lbound.imax, rbound.imax);
-                                break;
-                            case BETREE_FLOAT:
-                                bound->fmax = fmax(lbound.fmax, rbound.fmax);
-                                break;
-                            case BETREE_STRING:
-                            case BETREE_STRING_LIST:
-                            case BETREE_INTEGER_ENUM:
-                                bound->smax = smax(lbound.smax, rbound.smax);
-                                break;
-                            case BETREE_SEGMENTS:
-                            case BETREE_FREQUENCY_CAPS:
-                            default:
-                                break;
-                        }
+                    if (is_reversed) {
+                        get_variable_bound_ast_bool_and(domain, node, bound, is_reversed, dirty);
+                    } else {
+                        get_variable_bound_ast_bool_or(domain, node, bound, is_reversed, dirty);
                     }
                     return;
                 }
                 case AST_BOOL_AND: {
-                    struct value_bound lbound = { .value_type = bound->value_type };
-                    struct bound_dirty ldirty = { .min_dirty = false, .max_dirty = false };
-                    struct value_bound rbound = { .value_type = bound->value_type };
-                    struct bound_dirty rdirty = { .min_dirty = false, .max_dirty = false };
-                    get_variable_bound_inner(
-                        domain, node->bool_expr.binary.lhs, &lbound, is_reversed, &ldirty);
-                    get_variable_bound_inner(
-                        domain, node->bool_expr.binary.rhs, &rbound, is_reversed, &rdirty);
-                    if(ldirty.min_dirty == true || rdirty.min_dirty == true) {
-                        dirty->min_dirty = true;
-                        switch(bound->value_type) {
-                            case BETREE_BOOLEAN:
-                                if(ldirty.min_dirty == true && rdirty.min_dirty == true) {
-                                    bound->bmin = lbound.bmin && rbound.bmin;
-                                }
-                                else if(ldirty.min_dirty == true) {
-                                    bound->bmin = lbound.bmin;
-                                }
-                                else {
-                                    bound->bmin = rbound.bmin;
-                                }
-                                break;
-                            case BETREE_INTEGER:
-                            case BETREE_INTEGER_LIST:
-                                if(ldirty.min_dirty == true && rdirty.min_dirty == true) {
-                                    bound->imin = d64min(lbound.imin, rbound.imin);
-                                }
-                                else if(ldirty.min_dirty == true) {
-                                    bound->imin = lbound.imin;
-                                }
-                                else {
-                                    bound->imin = rbound.imin;
-                                }
-                                break;
-                            case BETREE_FLOAT:
-                                if(ldirty.min_dirty == true && rdirty.min_dirty == true) {
-                                    bound->fmin = fmin(lbound.fmin, rbound.fmin);
-                                }
-                                else if(ldirty.min_dirty == true) {
-                                    bound->fmin = lbound.fmin;
-                                }
-                                else {
-                                    bound->fmin = rbound.fmin;
-                                }
-                                break;
-                            case BETREE_STRING:
-                            case BETREE_STRING_LIST:
-                            case BETREE_INTEGER_ENUM:
-                                if(ldirty.min_dirty == true && rdirty.min_dirty == true) {
-                                    bound->smin = smin(lbound.smin, rbound.smin);
-                                }
-                                else if(ldirty.min_dirty == true) {
-                                    bound->smin = lbound.smin;
-                                }
-                                else {
-                                    bound->smin = rbound.smin;
-                                }
-                                break;
-                            case BETREE_SEGMENTS:
-                            case BETREE_FREQUENCY_CAPS:
-                            default:
-                                break;
-                        }
-                    }
-                    if(ldirty.max_dirty == true || rdirty.max_dirty == true) {
-                        dirty->max_dirty = true;
-                        switch(bound->value_type) {
-                            case BETREE_BOOLEAN:
-                                if(ldirty.max_dirty == true && rdirty.max_dirty == true) {
-                                    bound->bmax = lbound.bmax || rbound.bmax;
-                                }
-                                else if(ldirty.max_dirty == true) {
-                                    bound->bmax = lbound.bmax;
-                                }
-                                else {
-                                    bound->bmax = rbound.bmax;
-                                }
-                                break;
-                            case BETREE_INTEGER:
-                            case BETREE_INTEGER_LIST:
-                                if(ldirty.max_dirty == true && rdirty.max_dirty == true) {
-                                    bound->imax = d64max(lbound.imax, rbound.imax);
-                                }
-                                else if(ldirty.max_dirty == true) {
-                                    bound->imax = lbound.imax;
-                                }
-                                else {
-                                    bound->imax = rbound.imax;
-                                }
-                                break;
-                            case BETREE_FLOAT:
-                                if(ldirty.max_dirty == true && rdirty.max_dirty == true) {
-                                    bound->fmax = fmax(lbound.fmax, rbound.fmax);
-                                }
-                                else if(ldirty.max_dirty == true) {
-                                    bound->fmax = lbound.fmax;
-                                }
-                                else {
-                                    bound->fmax = rbound.fmax;
-                                }
-                                break;
-                            case BETREE_STRING:
-                            case BETREE_STRING_LIST:
-                            case BETREE_INTEGER_ENUM:
-                                if(ldirty.max_dirty == true && rdirty.max_dirty == true) {
-                                    bound->smax = smax(lbound.smax, rbound.smax);
-                                }
-                                else if(ldirty.max_dirty == true) {
-                                    bound->smax = lbound.smax;
-                                }
-                                else {
-                                    bound->smax = rbound.smax;
-                                }
-                                break;
-                            case BETREE_SEGMENTS:
-                            case BETREE_FREQUENCY_CAPS:
-                            default:
-                                break;
-                        }
+                    if (is_reversed) {
+                        get_variable_bound_ast_bool_or(domain, node, bound, is_reversed, dirty);
+                    } else {
+                        get_variable_bound_ast_bool_and(domain, node, bound, is_reversed, dirty);
                     }
                     return;
                 }

--- a/tests/betree_tests.c
+++ b/tests/betree_tests.c
@@ -1652,6 +1652,102 @@ int test_duplicate_unsorted_string_list()
     return 0;
 }
 
+int test_cdir_not_and()
+{
+    struct betree* tree = betree_make();
+
+    add_attr_domain_b(tree->config, "p1", false);
+    add_attr_domain_b(tree->config, "p2", false);
+    add_attr_domain_b(tree->config, "p3", false);
+
+    // p1 = true, p2 = true, p3 = false
+    const char* event_str = "{\"p1\":true,\"p2\":true,\"p3\":false}";
+
+    struct report* report = make_report();
+
+    const char* expr1 = "p1 or (p2 and p3)";
+    // p1 or (p2 and p3) = true or (true and false) = true
+    betree_sub_t id1 = 101;
+    mu_assert(betree_insert(tree, id1, expr1), "");
+
+    const char* expr2 = "(p3 and p1) or p2";
+    // (p3 and p1) or p2 = (false and true) or true = true
+    betree_sub_t id2 = 202;
+    mu_assert(betree_insert(tree, id2, expr2), "");
+
+    const char* expr3 = "(not (p3 and p1)) and p2";
+    // (not (p3 and p1)) and p2 = (not (false and true)) and true =
+    // = (not false) and true = true
+    betree_sub_t id3 = 303;
+    mu_assert(betree_insert(tree, id3, expr3), "");
+
+    const char* expr4 = "(p2 or p3) or p1";
+    // (p2 or p3) or p1 = (true or false) or true = true
+    betree_sub_t id4 = 404;
+    mu_assert(betree_insert(tree, id4, expr4), "");
+
+    mu_assert(betree_search(tree, event_str, report), "");
+    mu_assert(report->evaluated == 4, "");
+    mu_assert(report->matched == 4, "");
+    mu_assert(report->subs[0] == id1, "");
+    mu_assert(report->subs[1] == id2, "");
+    mu_assert(report->subs[2] == id4, "");
+    mu_assert(report->subs[3] == id3, "");
+
+    free_report(report);
+    betree_free(tree);
+
+    return 0;
+}
+
+int test_cdir_not_or()
+{
+    struct betree* tree = betree_make();
+
+    add_attr_domain_b(tree->config, "p1", false);
+    add_attr_domain_b(tree->config, "p2", false);
+    add_attr_domain_b(tree->config, "p3", false);
+
+    // p1 = false, p2 = true, p3 = false
+    const char* event_str = "{\"p1\":false,\"p2\":true,\"p3\":false}";
+
+    struct report* report = make_report();
+
+    const char* expr2 = "p1 or (p2 or p3)";
+    // p1 or (p2 or p3) = false or (true or false) = true
+    betree_sub_t id2 = 202;
+    mu_assert(betree_insert(tree, id2, expr2), "");
+
+    const char* expr3 = "(p1 and p2) or p3";
+    // (p1 and p2) or p3 = (false and true) or false = false
+    betree_sub_t id3 = 303;
+    mu_assert(betree_insert(tree, id3, expr3), "");
+
+    const char* expr4 = "(not ((not p1) and p3)) and p2";
+    // (not ((not p1) and p3)) and p2 = (not ((not false) and false)) and true =
+    // = (not (true and false)) and true = (not false) and true = true
+    betree_sub_t id4 = 404;
+    mu_assert(betree_insert(tree, id4, expr4), "");
+
+    const char* expr1 = "p2 and not (p3 or p1)";
+    // p2 and not (p3 or p1) = true and not (false or false) =
+    // = true and not false = true
+    betree_sub_t id1 = 101;
+    mu_assert(betree_insert(tree, id1, expr1), "");
+
+    mu_assert(betree_search(tree, event_str, report), "");
+    mu_assert(report->evaluated >= 3, "");
+    mu_assert(report->matched == 3, "");
+    mu_assert(report->subs[0] == id2, "");
+    mu_assert(report->subs[1] == id4, "");
+    mu_assert(report->subs[2] == id1, "");
+
+    free_report(report);
+    betree_free(tree);
+
+    return 0;
+}
+
 int all_tests()
 {
     mu_run_test(test_int_enum);
@@ -1697,6 +1793,8 @@ int all_tests()
     mu_run_test(test_frequency_bug);
     mu_run_test(test_duplicate_unsorted_integer_list);
     mu_run_test(test_duplicate_unsorted_string_list);
+    mu_run_test(test_cdir_not_and);
+    mu_run_test(test_cdir_not_or);
 
     return 0;
 }


### PR DESCRIPTION
Observation: when using `erl-be-tree` some boolean expressions that evaluate to `true` are not included in the result of `erl_betree:betree_search/2`.

For example, expressions
`p1 or (p2 and p3)`,
`(p3 and p1) or p2`,
`(not (p3 and p1)) and p2`,
`(p2 or p3) or p1`,
where
`{p1, bool, disallow_undefined}`,
`{p2, bool, disallow_undefined}`,
`{p3, bool, disallow_undefined}`,
when evaluated with `p1=true`, `p2=true`, `p3=false`
are all `true`.

However, `erl_betree:betree_search` returns `3` matched expressions instead of `4`.
The expression `(not (p3 and p1)) and p2` is omitted from the `betree_search` result.

Brief description: during BE-Tree build procedure, `erl_betree:betree_insert_sub/2`, `betree_insert_sub` (betree.c),
the BE-Tree is constructed the way to facilitate rejection of the boolean expressions without even evaluating them.

Root cause: The BE-Tree construction is incorrect for expressions with clauses `not (A and B)`, `not (A or B)`.
The incorrect BE-Tree construction for such expressions causes rejection of boolean expressions that are `true`.

Fix: Use De Morgan's laws for expressions with clauses `not (A and B)`, `not (A or B)`:
`not (A and B) = (not A) or (not B)`;
`not (A or B) = (not A) and (not B)`.