### PR TITLE
Make functions 'add_sub', 'make_undefined' accessible outside of the 'be-tree' lib

### DIFF
--- a/src/debug.c
+++ b/src/debug.c
@@ -701,7 +701,7 @@ struct gathered_subs {
     struct betree_sub** subs;
 };
 
-static void add_sub(const struct betree_sub* sub, struct gathered_subs* gatherer)
+static void add_sub_debug(const struct betree_sub* sub, struct gathered_subs* gatherer)
 {
     if(gatherer->count == 0) {
         gatherer->subs = bcalloc(sizeof(*gatherer->subs));
@@ -754,7 +754,7 @@ static void gather_subs_pdir(const struct pdir* pdir, struct gathered_subs* gath
 static void gather_subs_cnode(const struct cnode* cnode, struct gathered_subs* gatherer)
 {
     for(size_t i = 0; i < cnode->lnode->sub_count; i++) {
-        add_sub(cnode->lnode->subs[i], gatherer);
+        add_sub_debug(cnode->lnode->subs[i], gatherer);
     }
     if(cnode->pdir != NULL) {
         gather_subs_pdir(cnode->pdir, gatherer);

--- a/src/tree.c
+++ b/src/tree.c
@@ -1854,7 +1854,7 @@ void free_memoize(struct memoize memoize)
     bfree(memoize.fail);
 }
 
-static uint64_t* make_undefined(size_t attr_domain_count, const struct betree_variable** preds)
+uint64_t* make_undefined(size_t attr_domain_count, const struct betree_variable** preds)
 {
     size_t count = attr_domain_count / 64 + 1;
     uint64_t* undefined = bcalloc(count * sizeof(*undefined));
@@ -1878,7 +1878,7 @@ uint64_t* make_undefined_with_count(size_t attr_domain_count, const struct betre
     return undefined;
 }
 
-static void add_sub(betree_sub_t id, struct report* report)
+void add_sub(betree_sub_t id, struct report* report)
 {
     if(report->matched == 0) {
         report->subs = bcalloc(sizeof(*report->subs));

--- a/src/tree.h
+++ b/src/tree.h
@@ -91,6 +91,7 @@ struct subs_to_eval {
 
 void init_subs_to_eval(struct subs_to_eval* subs);
 void init_subs_to_eval_ext(struct subs_to_eval* subs, size_t init);
+uint64_t* make_undefined(size_t attr_domain_count, const struct betree_variable** preds);
 uint64_t* make_undefined_with_count(size_t attr_domain_count, const struct betree_variable** preds, size_t* count);
 struct memoize make_memoize_with_count(size_t pred_count, size_t* count);
 void match_be_tree(const struct attr_domain** attr_domains,
@@ -115,6 +116,7 @@ bool match_sub_counting(size_t attr_domains_count,
     const uint64_t* undefined);
 void add_sub_counting(betree_sub_t id, struct report_counting* report);
 
+void add_sub(betree_sub_t id, struct report* report);
 void free_sub(struct betree_sub* sub);
 void free_event(struct betree_event* event);
 


### PR DESCRIPTION
Project `erl-be-tree` will use functions `add_sub`, `make_undefined`.
The `static` specifier for these functions has been removed.