### PR TITLE
fix(make): cross-compile support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ neato:
 	#$(CC) -shared $(OBJECTS) -o $@
 
 build/libbetree.a: build $(OBJECTS)
-	ar rcs $@ $(OBJECTS)
+	$(AR) rcs $@ $(OBJECTS)
 
 build:
 	mkdir -p build


### PR DESCRIPTION
[PEDSP-6400]

I'm looking to cross-compile this using `zig` so that I can run the go wrapper on my mac in this PR:  https://github.com/adgear/go-be-tree/pull/5

example:
```bash
make clean build/libbetree.a CC="zig cc -target aarch64-macos" AR="zig ar"
```

default value for `AR` is `ar` so there shouldn't be any backwards incompatibility issues: https://www.gnu.org/software/make/manual/make.html#Implicit-Variables

[PEDSP-6400]: https://adgear.atlassian.net/browse/PEDSP-6400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ